### PR TITLE
fix: replace execAsync with await execa

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,15 +8,15 @@ import { BackmergeConfig } from "./lib/models/config"
 
 /**
  * verifyConditions is the exported function for semantic-release for verifyConditions lifecycle.
- * 
+ *
  * It verifies the input plugin configuration and throws an error if it's not valid.
- * 
+ *
  * @param globalConfig the semantic-release-backmerge plugin configuration.
  * @param context the semantic-release context.
- * 
+ *
  * @returns the validated configuration.
- * 
- * @throws an exception in case the input semantic-release-backmerge configuration is invalid 
+ *
+ * @throws an exception in case the input semantic-release-backmerge configuration is invalid
  * or missing inputs like tokens or URLs, etc.
  */
 export const verifyConditions = (globalConfig: BackmergeConfig, context: VerifyConditionsContext) => {
@@ -30,9 +30,9 @@ export const verifyConditions = (globalConfig: BackmergeConfig, context: VerifyC
 
 /**
  * success is the function for semantic-release success lifecycle.
- * 
- * It executes the backmerge to all appropriate branches as the release was successfull.
- * 
+ *
+ * It executes the backmerge to all appropriate branches as the release was successful.
+ *
  * @param globalConfig the semantic-release-backmerge plugin configuration.
  * @param context the semantic-release context.
  */
@@ -40,7 +40,11 @@ export const success = async (globalConfig: BackmergeConfig, context: SuccessCon
     const config = verifyConditions(globalConfig, context)
 
     try {
-        const branches = getBranches(context, config)
+        // Add await since getBranches is asynchronous
+        const branches = await getBranches(context, config)
+
+        console.log(`DEBUG: [success] Raw output from 'ls': ${JSON.stringify(branches)}`);
+
         await executeBackmerge(context, config, branches)
     } catch (error) {
         if (error instanceof AggregateError || error instanceof SemanticReleaseError) {

--- a/lib/backmerge.ts
+++ b/lib/backmerge.ts
@@ -10,6 +10,7 @@ import semver from "semver"
 import { BackmergeConfig } from "./models/config"
 import { authModificator } from "./auth-modificator"
 import { template } from "lodash"
+import { Buffer } from "buffer"
 
 /**
  * Context is a subinterface of semantic-release Context (specifically VerifyConditionContext)
@@ -27,18 +28,18 @@ export interface Context {
 }
 
 /**
- * getBranches returns the slice of branches that can be backmerged. 
- * To retrieve them, it takes into account their existence in remote repository, their presence in input targets, 
+ * getBranches returns the slice of branches that can be backmerged.
+ * To retrieve them, it takes into account their existence in remote repository, their presence in input targets,
  * and their semver version value related to the appropriate target (for instance, a branch v1.0 won't be returned if target.from is v1.1).
- * 
+ *
  * @param context with logger, released branch, current directory and environment.
  * @param config the semantic-release-backmerge plugin configuration.
- * 
+ *
  * @throws an error in case the input remote can't be fetched or the branches can be retrieved with git.
- * 
+ *
  * @returns the slice of branches where the context.branch.name must be backmerged into.
  */
-export const getBranches = (context: Context, config: BackmergeConfig) => {
+export const getBranches = async (context: Context, config: BackmergeConfig) => {
     const releaseBranch = context.branch.name
 
     const appropriates = config.targets.filter(branch => releaseBranch.match(branch.from))
@@ -46,90 +47,93 @@ export const getBranches = (context: Context, config: BackmergeConfig) => {
         context.logger.log(`Current branch '${releaseBranch}' doesn't match any configured backmerge targets.`)
         return []
     }
-    context.logger.log(`Current branch '${releaseBranch}' matches following configured backmerge targets: '${JSON.stringify(appropriates)}'. Performing backmerge.`)
+    context.logger.log(`Current branch '${releaseBranch}' matches configured backmerge targets: '${JSON.stringify(appropriates)}'. Performing backmerge.`)
 
     const url = parse(config.repositoryUrl)
     const authRemote = authModificator(url, config.platform, config.token)
+    const authRemoteBase64 = Buffer.from(authRemote).toString('base64')
 
-    // ensure at any time and any moment that the fetch'ed remote url is the same as there
-    // https://github.com/semantic-release/git/blob/master/lib/prepare.js#L69
-    // it's to ensure that the commit done during @semantic-release/git is backmerged alongside the other commits
-    fetch(authRemote, context.cwd, context.env)
+    context.logger.log(`DEBUG: Auth remote URL: ${authRemote}`)
+    context.logger.log(`DEBUG: Auth remote URL (base64): ${authRemoteBase64}`)
 
-    const branches = ls(config.repositoryUrl, context.cwd, context.env).
-        // don't keep the released branch
-        filter(branch => releaseBranch !== branch).
+    await fetch(authRemote, context.cwd, context.env)
 
-        // don't keep branches that doesn't match 'to' regexp
-        filter(branch => appropriates.map(target => target.to).find(target => branch.match(target))).
+    // Ensure ls returns an array and is awaited properly
+    let branches: string[] = []
+    try {
+        branches = await ls(config.repositoryUrl, context.cwd, context.env)
 
-        // only keep upper version when it's a semver released branch
-        // for instance v1 must not backmerge into anyone
-        // for instance v1.5 must backmerge into v1.6, v1.7, etc.
-        filter(branch => {
+        console.log(`DEBUG: [getBranches] Branches: ${JSON.stringify(branches)}`);
+        console.log(typeof 'branches');
+
+        if (!Array.isArray(branches)) {
+            throw new Error("ls did not return an array.")
+        }
+    } catch (error) {
+        context.logger.error("Failed to retrieve branches from remote.", error)
+        throw new Error("Failed to retrieve branches.")
+    }
+
+    branches = branches
+        .filter(branch => releaseBranch !== branch)
+        .filter(branch => appropriates.map(target => target.to).find(target => branch.match(target)))
+        .filter(branch => {
             const releaseMaintenance = semver.valid(semver.coerce(releaseBranch))
             const branchMaintenance = semver.valid(semver.coerce(branch))
 
             if (releaseMaintenance && branchMaintenance) {
-                // don't keep branches of other major versions
                 const nextMajor = semver.inc(releaseMaintenance, "major")
                 const currentMajor = semver.coerce(semver.major(releaseMaintenance))!
 
-                // don't keep any branches if the current branch is the major branch (like v1 or v1.x)
                 if (semver.eq(releaseMaintenance, currentMajor)) {
                     return false
                 }
 
-                // don't merge into older versions
                 if (semver.lt(branchMaintenance, releaseMaintenance)) {
-                    context.logger.log(`Not backmerging into '${branch}' since the semver version is before '${releaseBranch}'.`)
+                    context.logger.log(`Not backmerging into '${branch}' since semver version is before '${releaseBranch}'.`)
                     return false
                 }
 
-                // don't merge minor versions into next majors versions
                 if (semver.gte(branchMaintenance, nextMajor!)) {
-                    context.logger.log(`Not backmerging into '${branch}' since the semver major version is after '${releaseBranch}'.`)
+                    context.logger.log(`Not backmerging into '${branch}' since semver major version is after '${releaseBranch}'.`)
                     return false
                 }
             }
             return true
         })
+
     if (branches.length === 0) {
         context.logger.log("No configured target is present in remote origin, no backmerge to be done.")
         return []
     }
-    context.logger.log(`Retrieved following branches present in remote origin: '${JSON.stringify(branches)}'`)
+    context.logger.log(`Retrieved branches present in remote origin: '${JSON.stringify(branches)}'`)
     return branches
 }
 
-/**
- * executeBackmerge runs a backmerge from context.branch.name into all input branches.
- * For that, it runs a fetch of input remote, then a checkout of the released branch (to ensure all commits are up to date) 
- * and then merge released branch into each branch from branches.
- * If a merge fails, it tries to create a pull request.
- * 
- * @param context input context with the logger, released branch, etc.
- * @param config the semantic-release-backmerge plugin configuration.
- * @param branches slice of branches to be backmerged with released branch commits.
- * 
- * @throws AggregateError of SemanticReleaseError(s) for each branch that couldn't be backmerged.
- */
+
 export const executeBackmerge = async (context: Context, config: BackmergeConfig, branches: string[]) => {
     const releaseBranch = context.branch.name
 
     const url = parse(config.repositoryUrl)
     const authRemote = authModificator(url, config.platform, config.token)
+    const authRemoteBase64 = Buffer.from(authRemote).toString('base64')
 
-    // ensure at any time and any moment that the fetch'ed remote url is the same as there
-    // https://github.com/semantic-release/git/blob/master/lib/prepare.js#L69
-    // it's to ensure that the commit done during @semantic-release/git is backmerged alongside the other commits
-    fetch(authRemote, context.cwd, context.env)
+    context.logger.log(`DEBUG: Auth remote URL: ${authRemote}`)
+    context.logger.log(`DEBUG: Auth remote URL (base64): ${authRemoteBase64}`)
 
-    // checkout to ensure released branch is up to date with last fetch'ed remote url
-    checkout(releaseBranch, context.cwd, context.env)
+    await fetch(authRemote, context.cwd, context.env)
+
+    // Checkout to ensure released branch is up to date with last fetched remote URL
+    await checkout(releaseBranch, context.cwd, context.env)
+
+    // Ensure branches is an array
+    if (!Array.isArray(branches)) {
+        throw new Error("DEBUG: 'branches' is not an array.")
+    }
 
     const errors: SemanticReleaseError[] = []
-    for (const branch of branches) { // keep await in loop since git actions aren't thread safe
+    for (const branch of branches) { // keep await in loop since git actions aren't thread-safe
+        context.logger.log(`Processing backmerge from '${releaseBranch}' into '${branch}'`)
         const templateData = {
             from: releaseBranch,
             lastRelease: context.lastRelease,
@@ -138,12 +142,12 @@ export const executeBackmerge = async (context: Context, config: BackmergeConfig
         }
 
         try {
-            merge(releaseBranch, branch, template(config.commit)(templateData), context.cwd, context.env)
+            await merge(releaseBranch, branch, template(config.commit)(templateData), context.cwd, context.env)
 
             if (config.dryRun) {
                 context.logger.log(`Running with --dry-run, push to '${branch}' will not update remote state.`)
             }
-            push(authRemote, branch, config.dryRun, context.cwd, context.env)
+            await push(authRemote, branch, config.dryRun, context.cwd, context.env)
         } catch (error) {
             context.logger.error(`Failed to backmerge '${releaseBranch}' into '${branch}', opening pull request.`, error)
 

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -1,80 +1,105 @@
-import { execaSync } from "execa"
+import { execa } from "execa"
 
 /**
- * ls returns the slice of all branches present in remote origin. 
+ * ls returns the slice of all branches present in remote origin.
  * It removes 'refs/heads/' from the branches name.
- * 
+ *
  * @returns the slice of branches.
- * 
- * @throws an error is the git ls-remote cannot be done.
+ *
+ * @throws an error if the git ls-remote cannot be done.
  */
-export const ls = (remote: string, cwd?: string, env?: Record<string, string>) => {
-    const { stdout } = execaSync("git", ["ls-remote", "--heads", remote], { cwd, env })
+export const ls = async (remote: string, cwd?: string, env?: Record<string, string>) => {
+    console.log(`DEBUG: Listing branches for remote '${remote}' with cwd='${cwd}'`)
+    const { stdout } = await execa("git", ["ls-remote", "--heads", remote], {cwd, env})
+    console.log(`DEBUG: ls-remote output: ${stdout}`)
     const branches = stdout.
         split("\n").
         map(branch => branch.split("\t")).
         flat().
         filter(branch => branch.startsWith("refs/heads/")).
         map(branch => branch.replace("refs/heads/", ""))
+    console.log(`DEBUG: Parsed branches: ${branches}`)
     return [...new Set(branches)]
 }
 
 /**
- * checkout executes a simple checkout of input branch. 
+ * checkout executes a simple checkout of input branch.
  * The checkout is strict with remote state, meaning all local changes are removed.
- * 
+ *
  * @param branch the input branch to checkout.
- * 
+ *
  * @throws an error if the checkout cannot be done.
  */
-export const checkout = (branch: string, cwd?: string, env?: Record<string, string>) => {
-    execaSync("git", ["checkout", "-B", branch], { cwd, env })
+export const checkout = async (branch: string, cwd?: string, env?: Record<string, string>) => {
+    console.log(`DEBUG: Checking out branch '${branch}' with cwd='${cwd}'`)
+    await execa("git", ["checkout", "-B", branch], {cwd, env})
 }
 
 /**
  * fetch executes a simple fetch of input remote.
- * 
+ *
  * @param remote the remote to fetch branches from.
- * 
+ *
  * @throws an error if the fetch cannot be done.
  */
-export const fetch = (remote: string, cwd?: string, env?: Record<string, string>) => {
-    execaSync("git", ["fetch", remote], { cwd, env })
+export const fetch = async (remote: string, cwd?: string, env?: Record<string, string>) => {
+    console.log(`DEBUG: Fetching remote '${remote}' with cwd='${cwd}'`)
+    await execa("git", ["fetch", remote], {cwd, env})
 }
 
 /**
  * merge executes a checkout of input 'to' branch, and merges input 'from' branch into 'to'.
  * If a merge commit must be done (by default --ff is used), then the merge commit is the input commit.
- * 
+ *
  * @param from the branch to merge into 'to'.
  * @param to the branch to merge changes from 'from'.
  * @param commit the merge commit message if one is done.
- * 
+ *
  * @throws an error if the merge fails (in case of conflicts, etc.).
  */
-export const merge = (from: string, to: string, commit: string, cwd?: string, env?: Record<string, string>) => {
-    checkout(to)
+export const merge = async (from: string, to: string, commit: string, cwd?: string, env?: Record<string, string>) => {
+    console.log(`DEBUG: Merging branch '${from}' into '${to}' with commit message '${commit}'`)
+
+    // Ensure we're checking out the target branch
+    await checkout(to, cwd, env);
 
     try {
-        execaSync("git", ["merge", `${from}`, "--ff", "-m", commit], { cwd, env })
+        console.log(`DEBUG: Executing merge with --ff option`)
+
+        // Try merging the branches
+        await execa("git", ["merge", `${from}`, "--ff", "-m", commit], {cwd, env});
+
+        console.log(`DEBUG: Merge of '${from}' into '${to}' completed successfully`);
     } catch (error) {
-        execaSync("git", ["merge", "--abort"], { cwd, env })
-        throw error
+        console.error(`DEBUG: Merge failed with error: ${error.message}`); // Log the error message
+        console.log(`DEBUG: Current branch after failed merge: ${await execa("git", ["rev-parse", "--abbrev-ref", "HEAD"], {cwd, env})}`); // Log current branch
+        console.log(`DEBUG: Last commit message on '${to}': ${await execa("git", ["log", "-1", "--pretty=%B"], {cwd, env})}`); // Log last commit message
+
+        // Attempt to abort the merge
+        console.log(`Attempting to abort merge due to failure`);
+        await execa("git", ["merge", "--abort"], {cwd, env});
+
+        console.log(`Merge aborted`);
+        throw error; // Rethrow the error after logging
     }
 }
 
+
 /**
  * push executes a simple git push to the input remote with the current checked out branch.
- * 
+ *
  * @param remote the remote to push changes to.
  * @param dryRun if the push must only verify if all conditions are fine and not alter the remote state.
- * 
+ *
  * @throws an error if the push cannot be executed.
  */
-export const push = (remote: string, branch: string, dryRun?: boolean, cwd?: string, env?: Record<string, string>) => {
+export const push = async (remote: string, branch: string, dryRun?: boolean, cwd?: string, env?: Record<string, string>) => {
+    console.log(`Pushing branch '${branch}' to remote '${remote}' with dryRun=${dryRun} and cwd='${cwd}'`)
     const args = ["push", remote, `HEAD:${branch}`]
     if (dryRun) {
+        console.log("Adding --dry-run to push command")
         args.push("--dry-run")
     }
-    execaSync("git", args, { cwd, env })
+    console.log(`Executing push with args: ${args}`)
+    await execa("git", args, {cwd, env})
 }


### PR DESCRIPTION
After investigating the issues https://github.com/kilianpaquier/semantic-release-backmerge/issues/17 I found out that the `execAsync` is the problem and needs to be replaced with `await execa` to make it work properly.

> **!! DO NOT MERGE !!** 
It contains a bunch of debug code that needs to be cleaned up first 😄 

This PR just serves to show the changes I made to make it work.