### PR TITLE
fix: typo in verifyConditions error message

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -33,7 +33,7 @@ export const verifyConditions = async (globalConfig: BackmergeConfig, context: V
         const stdout = await version(context.cwd, context.env);
         (context.logger as Logger).log(`Using git version: '${stdout}'.`)
     } catch (error) {
-        throw new SemanticReleaseError("Failed to ensure git is spwanable by backmerge process.", "EGITSPAWN", String(error))
+        throw new SemanticReleaseError("Failed to ensure git is spawnable by backmerge process.", "EGITSPAWN", String(error))
     }
 
     const config = ensureDefault(globalConfig, context.env)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -59,7 +59,7 @@ describe("verifyConditions", () => {
         const matcher = expect(async () => await verifyConditions(config, context))
 
         // Assert
-        matcher.toThrowError("Failed to ensure git is spwanable by backmerge process.")
+        matcher.toThrowError("Failed to ensure git is spawnable by backmerge process.")
     })
 
     test("should fail with at least one invalid config field", () => {


### PR DESCRIPTION
This PR fixes a minor typo in the check of `verifyConditions` whether `git` is spawnable.